### PR TITLE
Test getting time entry details

### DIFF
--- a/test/test_toggl.ml
+++ b/test/test_toggl.ml
@@ -120,6 +120,12 @@ module TestNormalBehaviour = struct
     >|= check Testables.time_entry "Same time entry" time_entry
     |> raise_error
 
+  let test_time_entry_details _switch () =
+    client
+    >>= Api.TimeEntry.details 436694100
+    >|= check Testables.time_entry "Same time entry" time_entry
+    |> raise_error
+
   let test_list_workspaces _switch () =
     client
     >>= Api.Workspace.list
@@ -149,6 +155,13 @@ module TestNotFound = struct
   let test_list_projects _switch () =
     client
     >>= Api.Project.list 0
+    |> map_err Piaf.Error.to_string
+    |> map_err (check string "Says that url is not found" "not_found")
+    |> Lwt.map Result.get_error
+
+  let test_time_entry_details _switch () =
+    client
+    >>= Api.TimeEntry.details 0
     |> map_err Piaf.Error.to_string
     |> map_err (check string "Says that url is not found" "not_found")
     |> Lwt.map Result.get_error
@@ -200,6 +213,14 @@ module TestConnectionError = struct
     |> map_err (check string "Returns error" "Connect Error: connection error")
     |> Lwt.map Result.get_error
 
+  let test_time_entry_details _switch () =
+    error_client
+    >>= Api.TimeEntry.stop 0
+    |> map_err Piaf.Error.to_string
+    |> map_err CCString.trim
+    |> map_err (check string "Returns error" "Connect Error: connection error")
+    |> Lwt.map Result.get_error
+
   let test_list_workspaces _switch () =
     error_client
     >>= Api.Workspace.list
@@ -218,18 +239,21 @@ let () =
       test_case "Starting time entry response is parsed" `Quick test_start_time_entry;
       test_case "Stopping time entry response is parsed" `Quick test_stop_time_entry;
       test_case "Getting current time entry response is parsed" `Quick test_current_time_entry;
+      test_case "Getting specified time entry response is parsed" `Quick test_time_entry_details;
       test_case "Getting all workspaces response is parsed" `Quick test_list_workspaces;
       test_case "Getting all projects response is parsed" `Quick test_list_projects;
     ];
     "Page not found", TestNotFound.[
       test_case "Stopping time entry response is parsed" `Quick test_stop_time_entry;
       test_case "Getting all projects response is parsed" `Quick test_list_projects;
+      test_case "Getting specified time entry response is parsed" `Quick test_time_entry_details;
     ];
     "Error case", TestConnectionError.[
       test_case "Creating time entry response returns error" `Quick test_create_time_entry;
       test_case "Starting time entry response returns error" `Quick test_start_time_entry;
       test_case "Stopping time entry response returns error" `Quick test_stop_time_entry;
       test_case "Getting current time entry response returns error" `Quick test_current_time_entry;
+      test_case "Getting specified time entry response returns error" `Quick test_time_entry_details;
       test_case "Getting all workspaces response returns error" `Quick test_list_workspaces;
       test_case "Getting all projects response returns error" `Quick test_list_projects;
     ];

--- a/test/togglClient.ml
+++ b/test/togglClient.ml
@@ -95,6 +95,7 @@ let get (_t: t) ?(headers: (string*string) list option) path =
   match path with
   | "/api/v8/workspaces/777/projects" -> Lwt_result.return (Response.of_string `OK ~body:projects)
   | "/api/v8/time_entries/current" -> Lwt_result.return (Response.of_string `OK ~body:time_entry)
+  | "/api/v8/time_entries/436694100" -> Lwt_result.return (Response.of_string `OK ~body:time_entry)
   | "/api/v8/workspaces" -> Lwt_result.return (Response.of_string `OK ~body:workspaces)
   | _ -> Lwt_result.return (Response.of_string ~body:"not_found" `Not_found)
 


### PR DESCRIPTION
Closes #2 

Implementation of the endpoint was already in master branch (committed there by mistake), this adds the unit testing.